### PR TITLE
fix(docs): correct wording from "the the object" to "the object"

### DIFF
--- a/node_modules/csv-parser/README.md
+++ b/node_modules/csv-parser/README.md
@@ -132,7 +132,7 @@ which specifies the headers to use. For example:
 csv(['Name', 'Age']);
 ```
 
-If you need to specify options _and_ headers, please use the the object notation
+If you need to specify options _and_ headers, please use the object notation
 with the `headers` property as shown below.
 
 #### escape


### PR DESCRIPTION
@zoxilsi ji 
PR Description:

This pull request fixes a minor typo in the documentation.

File Updated: MCA-STUDY-MATERIALS/node_modules/csv-parser/README.md

Change Made: Replaced the phrase "the the object" with "the object".

Motivation

Improves readability and maintains professionalism in the project documentation.

Do check and merge above pull request of issue number 55